### PR TITLE
Fix issue with installing via yarn

### DIFF
--- a/install.js
+++ b/install.js
@@ -16,15 +16,6 @@ const {
 } = require("./constants");
 const BUNDLETOOL_URL = `https://github.com/google/bundletool/releases/download/${BUNDLETOOL_VERSION}/bundletool-all-${BUNDLETOOL_VERSION}.jar`;
 
-const log = (message) => {
-  const logLevel = process.env.npm_config_loglevel;
-  const logLevelDisplay = ["silent", "error", "warn"].includes(logLevel);
-
-  if (!logLevelDisplay) {
-    console.log(message);
-  }
-};
-
 // process.env.npm_config_cache is not set if installing via yarn, and there's no
 // other env variable that determines the caching dir for yarn. so we'll need to fetch
 // yarn cache via terminal  (couldn't find another way to get yarn cache dir)
@@ -34,6 +25,15 @@ const log = (message) => {
 const CACHE_DIR = process.env.npm_config_user_agent.includes("yarn")
   ? spawnSync("yarn", ["cache", "dir"]).stdout.toString()
   : process.env.npm_config_cache;
+
+const log = (message) => {
+  const logLevel = process.env.npm_config_loglevel;
+  const logLevelDisplay = ["silent", "error", "warn"].includes(logLevel);
+
+  if (!logLevelDisplay) {
+    console.log(message);
+  }
+};
 
 const downloadBinary = () => {
   return new Promise(async (resolve, reject) => {

--- a/install.js
+++ b/install.js
@@ -1,4 +1,5 @@
 // @ts-check
+const { spawnSync } = require("child_process");
 const { existsSync, mkdirSync, createWriteStream } = require("fs");
 const axios = require("axios");
 const path = require("path");
@@ -23,6 +24,16 @@ const log = (message) => {
     console.log(message);
   }
 };
+
+// process.env.npm_config_cache is not set if installing via yarn, and there's no
+// other env variable that determines the caching dir for yarn. so we'll need to fetch
+// yarn cache via terminal  (couldn't find another way to get yarn cache dir)
+//
+// if installing through yarn npm_config_user_agent will have "yarn/<version>" (among other things)
+// if installing through npm, this variable only references npm / node.
+const CACHE_DIR = process.env.npm_config_user_agent.includes("yarn")
+  ? spawnSync("yarn", ["cache", "dir"]).stdout.toString()
+  : process.env.npm_config_cache;
 
 const downloadBinary = () => {
   return new Promise(async (resolve, reject) => {
@@ -70,28 +81,20 @@ const downloadBinary = () => {
 };
 
 function getBinaryCachePath() {
-  const cachePath = path.join(
-    process.env.npm_config_cache,
-    pkg.name,
-    pkg.version,
-  );
+  const cachePath = path.join(CACHE_DIR, pkg.name, pkg.version);
 
   try {
     mkdir.sync(cachePath);
     return cachePath;
   } catch (e) {
-    console.error('cache path not found!!! ' + cachePath); 
+    console.error("Cache path not found! " + cachePath);
   }
 
   return "";
 }
 
 function getCachedBinary() {
-  const cachePath = path.join(
-    process.env.npm_config_cache,
-    pkg.name,
-    pkg.version,
-  );
+  const cachePath = path.join(CACHE_DIR, pkg.name, pkg.version);
   const cacheBinary = path.join(cachePath, BUNDLETOOL_FILE_NAME);
 
   if (fs.existsSync(cacheBinary)) {


### PR DESCRIPTION
Apparently yarn doesn't specify an env variable for the caching directory (like it does for other things). This was causing install script to crash because we'd try to build a path using `undefined` as value which is not accepted.

There were two possible solutions here:
1. don't use global caching if installing through yarn
2. get yarn cache dir via terminal (couldn't find another way to get it)

I went with option two as it's what made more sense

@jpike88 since you added the global caching could you give it a check ? 

fixes https://github.com/Ribeiro-Tiago/bundletool/issues/11